### PR TITLE
Fix OpenMC temp settings for LTMR

### DIFF
--- a/core_design/openmc_template_LTMR.py
+++ b/core_design/openmc_template_LTMR.py
@@ -659,13 +659,10 @@ def build_openmc_model_LTMR(params):
     else:
         settings.particles = 1000
 
-    if params['Isothermal Temperature Coefficients']:
-        settings.temperature = {
-            'default': params['Common Temperature'],
-            'method': 'interpolation',
-            'tolerance': 50.0
-        }
-    else:
-        settings.temperature = {'method': 'interpolation'}
+    settings.temperature = {
+        'default': params['Common Temperature'],
+        'method': 'interpolation',
+        'tolerance': 50.0
+    }
 
     settings.export_to_xml()


### PR DESCRIPTION
This PR fixes the inconsistent temperature settings used by OpenMC. The same temperature settings is now applied whether the shutdown margin calculation is run alone or together with the isothermal temperature coefficient calculation resulting in consistent SDM results.